### PR TITLE
Lint plugin according to WordPress style guide.

### DIFF
--- a/nla-im-button-embed/nla-im-button-embed-admin.php
+++ b/nla-im-button-embed/nla-im-button-embed-admin.php
@@ -1,91 +1,97 @@
 <?php
 
-require_once( NLA_TOOLS__PLUGIN_DIR . 'nla-im-button-embed-functions.php' );
-require_once( NLA_TOOLS__PLUGIN_DIR . 'nla-im-button-embed-options.php' );
+require_once NLA_TOOLS__PLUGIN_DIR . 'nla-im-button-embed-functions.php';
+require_once NLA_TOOLS__PLUGIN_DIR . 'nla-im-button-embed-options.php';
 
 function nla_im_add_settings_page() {
-    add_options_page(
-        'IM Embed settings',
-        'IM Embed Settings',
-        'manage_options',
-        'nla-im-embed-menu',
-        'nla_im_render_plugin_settings_page'
-    );
+	add_options_page(
+		'IM Embed settings',
+		'IM Embed Settings',
+		'manage_options',
+		'nla-im-embed-menu',
+		'nla_im_render_plugin_settings_page'
+	);
 }
 add_action( 'admin_menu', 'nla_im_add_settings_page' );
 
 function nla_im_render_plugin_settings_page() {
-    ?>
-    <h2>IM Embed Settings</h2>
-    <form action="options.php" method="post">
-        <?php
-        settings_fields( 'nla_im_embed_plugin_options' );
-        do_settings_sections( 'nla_im_embed_plugin' ); ?>
-        <input name="submit" class="button button-primary" type="submit" value="<?php esc_attr_e( 'Save' ); ?>" />
-    </form>
-    <?php
+	?>
+	<h2>IM Embed Settings</h2>
+	<form action="options.php" method="post">
+		<?php
+		settings_fields( 'nla_im_embed_plugin_options' );
+		do_settings_sections( 'nla_im_embed_plugin' );
+		?>
+		<input name="submit" class="button button-primary" type="submit" value="<?php esc_attr_e( 'Save' ); ?>" />
+	</form>
+	<?php
 }
 
-function nla_im_register_settings()
-{
-    register_setting( 'nla_im_embed_plugin_options', 'nla_im_embed_plugin_options', 'nla_im_embed_plugin_options_validate' );
-    add_settings_section( 'settings', 'Settings', 'nla_im_embed_plugin_section_text', 'nla_im_embed_plugin' );
+function nla_im_register_settings() {
+	register_setting( 'nla_im_embed_plugin_options', 'nla_im_embed_plugin_options', 'nla_im_embed_plugin_options_validate' );
+	add_settings_section( 'settings', 'Settings', 'nla_im_embed_plugin_section_text', 'nla_im_embed_plugin' );
 
-    $options = nla_im_embed_config_options();
-    foreach ($options as $code => $option) {
-        add_settings_field(
-            'nla_im_embed_plugin_setting_' . $code,
-            $option['title'],
-            'nla_im_embed_plugin_setting',
-            $option['page'],
-            $option['section'],
-            [
-                'code' => $code,
-                'description' => $option['description'],
-                'size' => $option['size'] ?? null,
-            ]
-        );
-    }
+	$options = nla_im_embed_config_options();
+	foreach ( $options as $code => $option ) {
+		add_settings_field(
+			"nla_im_embed_plugin_setting_{$code}",
+			$option['title'],
+			'nla_im_embed_plugin_setting',
+			$option['page'],
+			$option['section'],
+			array(
+				'code'        => $code,
+				'description' => $option['description'],
+				'size'        => $option['size'] ?? null,
+			)
+		);
+	}
 }
 add_action( 'admin_init', 'nla_im_register_settings' );
 
-function nla_im_embed_plugin_options_validate($input)
-{
-    $newInput = [];
-    foreach (array_keys(nla_im_get_options()) as $key) {
-        $value = trim($input[$key] ?? '');
-        $newInput[$key] = $value ?: null;
-    }
+function nla_im_embed_plugin_options_validate( $input ) {
+	$new_input = array();
 
-    if ($newInput['base_url'] && substr($newInput['base_url'], -1) !== '/') {
-        $newInput['base_url'] = $newInput['base_url'] . '/';
-    }
+	foreach ( array_keys( nla_im_get_options() ) as $key ) {
+		$value             = trim( $input[ $key ] ?? '' );
+		$new_input[ $key ] = $value ?: null;
+	}
 
-    return $newInput;
+	if ( $new_input['base_url'] && substr( $new_input['base_url'], -1 ) !== '/' ) {
+		$new_input['base_url'] .= '/';
+	}
+
+	return $new_input;
 }
 
-function nla_im_embed_plugin_section_text()
-{
-    echo '<p>Here are the options for the NLA IM button plugin</p>';
+function nla_im_embed_plugin_section_text() {
+	echo '<p>Here are the options for the NLA IM button plugin</p>';
 }
 
-function nla_im_embed_plugin_setting($args)
-{
-    $code = $args['code'] ?? null;
-    $description = $args['description'] ?? null;
-    $size = $args['size'] ?? null;
+function nla_im_embed_plugin_setting( $args ) {
+	$code        = $args['code'] ?? null;
+	$description = $args['description'] ?? null;
+	$size        = $args['size'] ?? null;
 
-    if ($code) {
-        nla_im_text_field($code, nla_im_get_options()[$code], $description, $size );
-    }
+	if ( $code ) {
+		nla_im_text_field( $code, nla_im_get_options()[ $code ], $description, $size );
+	}
 }
 
-function nla_im_text_field($code, $value, $description = null, $size = 'regular')
-{
-    ?>
-    <input id="nla_im_embed_plugin_setting_<?= $code ?>" name="nla_im_embed_plugin_options[<?= $code ?>]" type="text"
-        value="<?= $value ?>" class="<?= $size ?>-text">
-    <?php if ($description) { ?>
-    <p id='base-url-description' class='description'><?= $description ?></p>
-    <?php }
+function nla_im_text_field( $code, $value, $description = null, $size = 'regular' ) {
+	echo esc_html(
+		<<<HTML
+		 <input
+			id="nla_im_embed_plugin_setting_{$code}"
+			name="nla_im_embed_plugin_options{$code}"
+			type="text"
+			value="{$value}"
+			class="{$size}-text"
+		 />
+		HTML
+	);
+
+	if ( $description ) {
+		echo esc_html( "<p id=\"base-url-description\" class=\"description\">{ $description }</p>" );
+	}
 }

--- a/nla-im-button-embed/nla-im-button-embed-functions.php
+++ b/nla-im-button-embed/nla-im-button-embed-functions.php
@@ -1,16 +1,15 @@
 <?php
 
-require_once( NLA_TOOLS__PLUGIN_DIR . 'nla-im-button-embed-options.php' );
+require_once NLA_TOOLS__PLUGIN_DIR . 'nla-im-button-embed-options.php';
 
-function nla_im_get_options()
-{
-    $storedOptions = get_option( 'nla_im_embed_plugin_options' );
-    $configOptions = nla_im_embed_config_options();
-    $returnOptions = [];
+function nla_im_get_options() {
+	$stored_options = get_option( 'nla_im_embed_plugin_options' );
+	$config_options = nla_im_embed_config_options();
+	$return_options = array();
 
-    foreach ($configOptions as $code => $option) {
-        $returnOptions[$code] = esc_attr($storedOptions[$code] ?? $option['default']);
-    }
+	foreach ( $config_options as $code => $option ) {
+		$return_options[ $code ] = esc_attr( $stored_options[ $code ] ?? $option['default'] );
+	}
 
-    return $returnOptions;
+	return $return_options;
 }

--- a/nla-im-button-embed/nla-im-button-embed-options.php
+++ b/nla-im-button-embed/nla-im-button-embed-options.php
@@ -1,38 +1,38 @@
 <?php
 
 function nla_im_embed_config_options() {
-    return array(
-        'base_url' => [
-            'title' => 'Base URL',
-            'page' => 'nla_im_embed_plugin',
-            'section' => 'settings',
-            'default' => null,
-            'description' => 'The URL that should be used to check for the IM status. Leave blank to use the default.',
-            'size' => 'regular',
-        ],
-        'open_text' => [
-            'title' => 'IM open text',
-            'page' => 'nla_im_embed_plugin',
-            'section' => 'settings',
-            'default' => 'Start chat',
-            'description' => 'The text that appears on the button when the IM Space is open.',
-            'size' => 'regular',
-        ],
-        'closed_text' => [
-            'title' => 'IM closed text',
-            'page' => 'nla_im_embed_plugin',
-            'section' => 'settings',
-            'default' => 'This service is currently closed, please check back again later.',
-            'description' => 'The text that appears when the IM Space is closed.',
-            'size' => 'large',
-        ],
-        'away_text' => [
-            'title' => 'IM away text',
-            'page' => 'nla_im_embed_plugin',
-            'section' => 'settings',
-            'default' => 'We are busy right, please come back in a bit.',
-            'description' => 'The text that appears when the IM Space is away.',
-            'size' => 'large',
-        ],
-    );
+	return array(
+		'base_url'    => array(
+			'title'       => 'Base URL',
+			'page'        => 'nla_im_embed_plugin',
+			'section'     => 'settings',
+			'default'     => null,
+			'description' => 'The URL that should be used to check for the IM status. Leave blank to use the default.',
+			'size'        => 'regular',
+		),
+		'open_text'   => array(
+			'title'       => 'IM open text',
+			'page'        => 'nla_im_embed_plugin',
+			'section'     => 'settings',
+			'default'     => 'Start chat',
+			'description' => 'The text that appears on the button when the IM Space is open.',
+			'size'        => 'regular',
+		),
+		'closed_text' => array(
+			'title'       => 'IM closed text',
+			'page'        => 'nla_im_embed_plugin',
+			'section'     => 'settings',
+			'default'     => 'This service is currently closed, please check back again later.',
+			'description' => 'The text that appears when the IM Space is closed.',
+			'size'        => 'large',
+		),
+		'away_text'   => array(
+			'title'       => 'IM away text',
+			'page'        => 'nla_im_embed_plugin',
+			'section'     => 'settings',
+			'default'     => 'We are busy right, please come back in a bit.',
+			'description' => 'The text that appears when the IM Space is away.',
+			'size'        => 'large',
+		),
+	);
 }

--- a/nla-im-button-embed/nla-im-button-embed-shortcodes.php
+++ b/nla-im-button-embed/nla-im-button-embed-shortcodes.php
@@ -1,49 +1,59 @@
 <?php
 
-require_once( NLA_TOOLS__PLUGIN_DIR . 'nla-im-button-embed-functions.php' );
+require_once NLA_TOOLS__PLUGIN_DIR . 'nla-im-button-embed-functions.php';
 
-function nla_im_button_embed_shortcode($atts = [], $content = null, $tag = '')
-{
-    // normalize attribute keys, lowercase
-    $atts = array_change_key_case( (array) $atts, CASE_LOWER );
+/** @throws \JsonException */
+function nla_im_button_embed_shortcode( $atts = array(), $content = null, $tag = '' ) {
+	 // Normalize attribute keys, lowercase.
+	$atts = array_change_key_case( (array) $atts );
 
-    // override default attributes with user attributes
-    $atts = shortcode_atts(
-        array(
-            'im-code' => null,
-            'align' => "left",
-        ), $atts, $tag
-    );
+	// Override default attributes with user attributes.
+	$atts = shortcode_atts(
+		array(
+			'im-code' => null,
+			'align'   => 'left',
+		),
+		$atts,
+		$tag
+	);
 
-    if (!($imCode = $atts['im-code'])) {
-        return '<div style="color:red;">No IM Instance provided!</div>';
-    }
+	$im_code = $atts['im_code'];
 
-    $options = nla_im_get_options();
-    $baseUrl = $options['base_url'] ?: 'https://portal.nightline.ac.uk/im/';
-    $baseUrl = "{$baseUrl}{$imCode}";
+	if ( ! ( $im_code ) ) {
+		return '<div style="color:red;">No IM Instance provided!</div>';
+	}
 
-    $response = wp_remote_get("{$baseUrl}?format=json");
-    if ($body = wp_remote_retrieve_body($response)) {
-        $data = json_decode($body);
+	$options  = nla_im_get_options();
+	$base_url = $options['base_url'] ?: 'https://portal.nightline.ac.uk/im/';
+	$base_url = "{$base_url}{$im_code}";
 
-        if (!$data) {
-            return '<div style="color:red;">Error checking the status of the IM service!</div>';
-        }
+	$response = wp_remote_get( "{$base_url}?format=json" );
+	$body     = wp_remote_retrieve_body( $response );
 
-        if ($data->open) {
-            if (property_exists($data, 'away') && $data->away) {
-                return "<div class='nla-im-embed-away has-text-align-{$atts['align']}'>{$options['away_text']}</div>";
-            } else {
-                return "<form action='{$baseUrl}/chats' class='wp-block-buttons nla-im-embed-open' method='POST' target='_blank'>
-    <div class='wp-block-button'>
-        <input class='wp-block-button__link nla-im-embed-open-chat-btn' type='submit' value='{$options['open_text']}'/>
-    </div>
-</form>";
-            }
-        } else {
-            return "<div class='nla-im-embed-closed has-text-align-{$atts['align']}'>{$options['closed_text']}</div>";
-        }
-    }
+	if ( $body ) {
+		$data = json_decode( $body, false, 512, JSON_THROW_ON_ERROR );
+
+		if ( ! $data ) {
+			return '<div style="color:red;">Error checking the status of the IM service!</div>';
+		}
+
+		if ( $data->open ) {
+			if ( property_exists( $data, 'away' ) && $data->away ) {
+				return "<div class='nla-im-embed-away has-text-align-{$atts['align']}'>{$options['away_text']}</div>";
+			}
+
+			return <<<HTML
+				<form action='{$base_url}/chats' class='wp-block-buttons nla-im-embed-open' method='POST' target='_blank'>
+					<div class='wp-block-button'>
+						<input class='wp-block-button__link nla-im-embed-open-chat-btn' type='submit' value='{$options['open_text']}'/>
+					</div>
+				</form>
+				HTML;
+		}
+
+		return "<div class='nla-im-embed-closed has-text-align-{$atts['align']}'>{$options['closed_text']}</div>";
+	}
+
+	return '';
 }
-add_shortcode('im_embed_btn', 'nla_im_button_embed_shortcode');
+add_shortcode( 'im_embed_btn', 'nla_im_button_embed_shortcode' );

--- a/nla-im-button-embed/nla-im-button-embed.php
+++ b/nla-im-button-embed/nla-im-button-embed.php
@@ -19,3 +19,8 @@ require_once NLA_TOOLS__PLUGIN_DIR . 'nla-im-button-embed-shortcodes.php';
 if ( ( defined( 'WP_CLI' ) && WP_CLI ) || is_admin() ) {
 	require_once NLA_TOOLS__PLUGIN_DIR . 'nla-im-button-embed-admin.php';
 }
+
+if ( ! function_exists( 'add_action' ) ) {
+	echo "Hello! I'm just a plugin. Not much I can when called directly.";
+	exit();
+}

--- a/nla-im-button-embed/nla-im-button-embed.php
+++ b/nla-im-button-embed/nla-im-button-embed.php
@@ -13,14 +13,14 @@ License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 define( 'NLA_TOOLS__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'NLA_TOOLS__PLUGIN_VER', '0.2.1' );
 
+if ( ! function_exists( 'add_action' ) ) {
+	echo "Hello! I'm just a plugin. Not much I can when called directly.";
+	exit();
+}
+
 require_once NLA_TOOLS__PLUGIN_DIR . 'nla-im-button-embed-functions.php';
 require_once NLA_TOOLS__PLUGIN_DIR . 'nla-im-button-embed-shortcodes.php';
 
 if ( ( defined( 'WP_CLI' ) && WP_CLI ) || is_admin() ) {
 	require_once NLA_TOOLS__PLUGIN_DIR . 'nla-im-button-embed-admin.php';
-}
-
-if ( ! function_exists( 'add_action' ) ) {
-	echo "Hello! I'm just a plugin. Not much I can when called directly.";
-	exit();
 }

--- a/nla-im-button-embed/nla-im-button-embed.php
+++ b/nla-im-button-embed/nla-im-button-embed.php
@@ -1,20 +1,20 @@
 <?php
-/*
+/**
 Plugin Name:  NLA IM Button Embed Plugin
 Plugin URI:   https://nightline.ac.uk
-Description:  Enables easy embedding of IM buttons onto wordpress sites.
-Version:      0.2
+Description:  Enables easy embedding of IM buttons onto WordPress sites.
+Version:      0.3
 Author:       Nightline Association
 Author URI:   https://nightline.ac.uk
 License:      GPL2
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
-*/
+ */
 
 define( 'NLA_TOOLS__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 
-require_once( NLA_TOOLS__PLUGIN_DIR . 'nla-im-button-embed-functions.php' );
-require_once( NLA_TOOLS__PLUGIN_DIR . 'nla-im-button-embed-shortcodes.php' );
+require_once NLA_TOOLS__PLUGIN_DIR . 'nla-im-button-embed-functions.php';
+require_once NLA_TOOLS__PLUGIN_DIR . 'nla-im-button-embed-shortcodes.php';
 
-if ( is_admin() || ( defined( 'WP_CLI' ) && WP_CLI ) ) {
-    require_once( NLA_TOOLS__PLUGIN_DIR . 'nla-im-button-embed-admin.php' );
+if ( ( defined( 'WP_CLI' ) && WP_CLI ) || is_admin() ) {
+	require_once NLA_TOOLS__PLUGIN_DIR . 'nla-im-button-embed-admin.php';
 }

--- a/nla-im-button-embed/nla-im-button-embed.php
+++ b/nla-im-button-embed/nla-im-button-embed.php
@@ -3,7 +3,7 @@
 Plugin Name:  NLA IM Button Embed Plugin
 Plugin URI:   https://nightline.ac.uk
 Description:  Enables easy embedding of IM buttons onto WordPress sites.
-Version:      0.3
+Version:      0.2.1
 Author:       Nightline Association
 Author URI:   https://nightline.ac.uk
 License:      GPL2
@@ -11,6 +11,7 @@ License URI:  https://www.gnu.org/licenses/gpl-2.0.html
  */
 
 define( 'NLA_TOOLS__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+define( 'NLA_TOOLS__PLUGIN_VER', '0.2.1' );
 
 require_once NLA_TOOLS__PLUGIN_DIR . 'nla-im-button-embed-functions.php';
 require_once NLA_TOOLS__PLUGIN_DIR . 'nla-im-button-embed-shortcodes.php';

--- a/nla-im-button-embed/nla-im-button-embed.php
+++ b/nla-im-button-embed/nla-im-button-embed.php
@@ -14,7 +14,7 @@ define( 'NLA_TOOLS__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'NLA_TOOLS__PLUGIN_VER', '0.2.1' );
 
 if ( ! function_exists( 'add_action' ) ) {
-	echo "Hello! I'm just a plugin. Not much I can when called directly.";
+	echo "Hello! I'm just a plugin. Not much I can do when called directly.";
 	exit();
 }
 


### PR DESCRIPTION
## Description

This PR is a proposal to format the plugin source code in a manner consistent with the WordPress PHP coding standards. https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/

WordPress is of course the black sheep of all PHP frameworks and libraries and utilises its own style system contrary to PSR recommendations. Nevertheless, I think public-facing source code should therefore be in a manner expected of software in the WP ecosystem, even if it means adhering to bizarre conventions, like tabs, like antiquated syntax: `array()` and the use of spaced parentheses.

Using PHPCS I have refactored the source code into a manner acceptable by WordPress, albeit some issues that I am unable to resolve:

- File doc comments expected of PHP files in WordPress are missing
- Doc comments for WordPress functions are missing
- Use of short ternaries - I happen to like `?:` operands and I'm not fully sold on removing them in favour of bulky `!empty($foo) ? $foo : $bar` statements

I propose that these comments are filled in either as part of this PR or in a follow-up, ideally prior to the next release.

Parameter and return typing have not been included as they are atypical in WordPress.

## Changes in this PR

- Linting, with minimal functional changes
- Some outputting of raw HTML has been refactored into heredoc syntax
- Guard clause added to prohibit direct access
- Version is now monitored within the codebase

## Testing

Testing 

It's extremely important to test this branch before merging.

1. Check out this branch to your development environment.
2. Ensure that the plugin works and renders correctly both in the WP dashboard and on the frontend
3. Ensure that various functionality continues to work